### PR TITLE
ControllerAdvice 설정 및  Error 구조 개편

### DIFF
--- a/back-end/src/main/java/admin/exception/BadRequestException.java
+++ b/back-end/src/main/java/admin/exception/BadRequestException.java
@@ -1,0 +1,7 @@
+package admin.exception;
+
+public class BadRequestException extends CustomException{
+    public BadRequestException(String message) {
+        super(message);
+    }
+}

--- a/back-end/src/main/java/admin/exception/BadRequestException.java
+++ b/back-end/src/main/java/admin/exception/BadRequestException.java
@@ -1,6 +1,7 @@
 package admin.exception;
 
-public class BadRequestException extends CustomException{
+public class BadRequestException extends CustomException {
+
     public BadRequestException(String message) {
         super(message);
     }

--- a/back-end/src/main/java/admin/exception/ControllerAdvice.java
+++ b/back-end/src/main/java/admin/exception/ControllerAdvice.java
@@ -1,6 +1,8 @@
 package admin.exception;
 
 import admin.exception.dto.ExceptionResponse;
+import admin.exception.http.BadRequestException;
+import admin.exception.http.NotFoundException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;

--- a/back-end/src/main/java/admin/exception/ControllerAdvice.java
+++ b/back-end/src/main/java/admin/exception/ControllerAdvice.java
@@ -1,0 +1,34 @@
+package admin.exception;
+
+import admin.exception.dto.ExceptionResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class ControllerAdvice {
+    private static Logger logger = LoggerFactory.getLogger(ControllerAdvice.class);
+
+    @ExceptionHandler(BadRequestException.class)
+    public ResponseEntity<ExceptionResponse> badRequestHandle(BadRequestException exception) {
+        ExceptionResponse response = ExceptionResponse.of(exception.getMessage());
+        return ResponseEntity.badRequest().body(response);
+    }
+
+    @ExceptionHandler(NotFoundException.class)
+    public ResponseEntity<ExceptionResponse> notFoundHandle(NotFoundException exception) {
+        ExceptionResponse response = ExceptionResponse.of(exception.getMessage());
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(response);
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ExceptionResponse> globalHandle(Exception exception) {
+        logger.error("Unhandled Exception", exception);
+
+        ExceptionResponse response = ExceptionResponse.of(exception.getMessage());
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(response);
+    }
+}

--- a/back-end/src/main/java/admin/exception/ControllerAdvice.java
+++ b/back-end/src/main/java/admin/exception/ControllerAdvice.java
@@ -12,6 +12,7 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 @RestControllerAdvice
 public class ControllerAdvice {
+
     private static Logger logger = LoggerFactory.getLogger(ControllerAdvice.class);
 
     @ExceptionHandler(BadRequestException.class)

--- a/back-end/src/main/java/admin/exception/CustomException.java
+++ b/back-end/src/main/java/admin/exception/CustomException.java
@@ -1,6 +1,6 @@
 package admin.exception;
 
-public class CustomException extends RuntimeException{
+public class CustomException extends RuntimeException {
 
     public CustomException(String message) {
         super(message);

--- a/back-end/src/main/java/admin/exception/CustomException.java
+++ b/back-end/src/main/java/admin/exception/CustomException.java
@@ -1,0 +1,8 @@
+package admin.exception;
+
+public class CustomException extends RuntimeException{
+
+    public CustomException(String message) {
+        super(message);
+    }
+}

--- a/back-end/src/main/java/admin/exception/NotFoundException.java
+++ b/back-end/src/main/java/admin/exception/NotFoundException.java
@@ -1,6 +1,6 @@
 package admin.exception;
 
-public class NotFoundException extends CustomException{
+public class NotFoundException extends CustomException {
 
     public NotFoundException(String message) {
         super(message);

--- a/back-end/src/main/java/admin/exception/NotFoundException.java
+++ b/back-end/src/main/java/admin/exception/NotFoundException.java
@@ -1,0 +1,8 @@
+package admin.exception;
+
+public class NotFoundException extends CustomException{
+
+    public NotFoundException(String message) {
+        super(message);
+    }
+}

--- a/back-end/src/main/java/admin/exception/dto/ExceptionResponse.java
+++ b/back-end/src/main/java/admin/exception/dto/ExceptionResponse.java
@@ -1,4 +1,4 @@
-package admin.gpuserver.dto.response;
+package admin.exception.dto;
 
 public class ExceptionResponse {
     private final String message;

--- a/back-end/src/main/java/admin/exception/http/BadRequestException.java
+++ b/back-end/src/main/java/admin/exception/http/BadRequestException.java
@@ -1,4 +1,4 @@
-package admin.exception;
+package admin.exception.http;
 
 public class BadRequestException extends CustomException {
 

--- a/back-end/src/main/java/admin/exception/http/CustomException.java
+++ b/back-end/src/main/java/admin/exception/http/CustomException.java
@@ -1,6 +1,6 @@
 package admin.exception.http;
 
-public class CustomException extends RuntimeException {
+public abstract class CustomException extends RuntimeException {
 
     public CustomException(String message) {
         super(message);

--- a/back-end/src/main/java/admin/exception/http/CustomException.java
+++ b/back-end/src/main/java/admin/exception/http/CustomException.java
@@ -1,4 +1,4 @@
-package admin.exception;
+package admin.exception.http;
 
 public class CustomException extends RuntimeException {
 

--- a/back-end/src/main/java/admin/exception/http/NotFoundException.java
+++ b/back-end/src/main/java/admin/exception/http/NotFoundException.java
@@ -1,4 +1,4 @@
-package admin.exception;
+package admin.exception.http;
 
 public class NotFoundException extends CustomException {
 

--- a/back-end/src/main/java/admin/gpuserver/application/GpuServerService.java
+++ b/back-end/src/main/java/admin/gpuserver/application/GpuServerService.java
@@ -16,6 +16,7 @@ import admin.job.domain.Job;
 import admin.job.domain.repository.JobRepository;
 import admin.lab.domain.Lab;
 import admin.lab.domain.repository.LabRepository;
+import admin.lab.exception.LabException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -45,7 +46,7 @@ public class GpuServerService {
     public GpuServerResponse findById(Long gpuServerId) {
         GpuServer gpuServer = findGpuServerById(gpuServerId);
         GpuBoard gpuBoard = gpuBoardRepository.findByGpuServerId(gpuServerId)
-                .orElseThrow(() -> new GpuServerException("존재하지 않는 보드입니다."));
+                .orElseThrow(GpuServerException.GPU_BOARD_NOT_FOUND::getException);
 
         List<Job> jobsInBoard = jobRepository.findAllByGpuBoardId(gpuBoard.getId());
         return GpuServerResponse.of(gpuServer, gpuBoard, jobsInBoard);
@@ -93,17 +94,17 @@ public class GpuServerService {
 
     private void validateLab(Long labId) {
         if (!labRepository.existsById(labId)) {
-            throw new GpuServerException("Lab이 존재하지 않습니다.");
+            throw LabException.LAB_NOT_FOUND.getException();
         }
     }
 
     private Lab findLabById(Long labId) {
         return labRepository.findById(labId)
-                .orElseThrow(() -> new GpuServerException("Lab이 존재하지 않습니다."));
+                .orElseThrow(LabException.LAB_NOT_FOUND::getException);
     }
 
     private GpuServer findGpuServerById(Long gpuServerId) {
         return gpuServerRepository.findByIdAndDeletedFalse(gpuServerId)
-                .orElseThrow(() -> new GpuServerException("GPU 서버가 존재하지 않습니다."));
+                .orElseThrow(GpuServerException.GPU_SERVER_NOT_FOUND::getException);
     }
 }

--- a/back-end/src/main/java/admin/gpuserver/application/GpuServerService.java
+++ b/back-end/src/main/java/admin/gpuserver/application/GpuServerService.java
@@ -11,6 +11,7 @@ import admin.gpuserver.dto.request.GpuServerRequest;
 import admin.gpuserver.dto.request.GpuServerUpdateRequest;
 import admin.gpuserver.dto.response.GpuServerResponse;
 import admin.gpuserver.dto.response.GpuServerResponses;
+import admin.gpuserver.exception.GpuBoardException;
 import admin.gpuserver.exception.GpuServerException;
 import admin.job.domain.Job;
 import admin.job.domain.repository.JobRepository;
@@ -46,7 +47,7 @@ public class GpuServerService {
     public GpuServerResponse findById(Long gpuServerId) {
         GpuServer gpuServer = findGpuServerById(gpuServerId);
         GpuBoard gpuBoard = gpuBoardRepository.findByGpuServerId(gpuServerId)
-                .orElseThrow(GpuServerException.GPU_BOARD_NOT_FOUND::getException);
+                .orElseThrow(GpuBoardException.GPU_BOARD_NOT_FOUND::getException);
 
         List<Job> jobsInBoard = jobRepository.findAllByGpuBoardId(gpuBoard.getId());
         return GpuServerResponse.of(gpuServer, gpuBoard, jobsInBoard);

--- a/back-end/src/main/java/admin/gpuserver/domain/DeleteHistory.java
+++ b/back-end/src/main/java/admin/gpuserver/domain/DeleteHistory.java
@@ -25,7 +25,7 @@ public class DeleteHistory extends BaseEntity {
 
     private void validate(GpuServer gpuServer) {
         if (Objects.isNull(gpuServer)) {
-            throw new DeleteHistoryException("DeleteHistory의 GpuServer 정보는 Null일 수 없습니다.");
+            throw DeleteHistoryException.INVALID_GPU_SERVER_ID.getException();
         }
     }
 }

--- a/back-end/src/main/java/admin/gpuserver/domain/GpuBoard.java
+++ b/back-end/src/main/java/admin/gpuserver/domain/GpuBoard.java
@@ -36,19 +36,19 @@ public class GpuBoard extends BaseEntity {
 
     private void validate(Boolean isWorking, Long performance, String modelName, GpuServer gpuServer) {
         if (Objects.isNull(performance) || performance <= 0) {
-            throw new GpuBoardException("잘못된 GpuBoard 정보 입력입니다.");
+            throw GpuBoardException.INVALID_PERFORMANCE.getException();
         }
 
         if (isWorking == null) {
-            throw new GpuBoardException("GpuBoard 상태는 Null일 수 없습니다.");
+            throw GpuBoardException.INVALID_STATUS.getException();
         }
 
         if (modelName == null || modelName.isEmpty()) {
-            throw new GpuBoardException("적절하지 않은 GpuBoard 이름 정보입니다.");
+            throw GpuBoardException.INVALID_MODEL.getException();
         }
 
         if (gpuServer == null) {
-            throw new GpuBoardException("GpuBoard의 GpuServer 정보는 Null일 수 없습니다.");
+            throw GpuBoardException.INVALID_GPU_SERVER_ID.getException();
         }
     }
 

--- a/back-end/src/main/java/admin/gpuserver/domain/GpuServer.java
+++ b/back-end/src/main/java/admin/gpuserver/domain/GpuServer.java
@@ -46,19 +46,19 @@ public class GpuServer extends BaseEntity {
 
     private void validate(String name, Boolean isOn, Long memorySize, Long diskSize, Lab lab) {
         if (Objects.isNull(name) || name.isEmpty()) {
-            throw new GpuServerException("적절한 GpuServer 이름이 아닙니다.");
+            throw GpuServerException.INVALID_NAME.getException();
         }
 
         if (Objects.isNull(isOn)) {
-            throw new GpuServerException("GpuServer의 상태는 Null일 수 없습니다.");
+            throw GpuServerException.INVALID_STATUS.getException();
         }
 
         if (memorySize == null || memorySize <= 0 || diskSize == null || diskSize <= 0) {
-            throw new GpuServerException("유효하지 않은 GpuServer 정보입니다.");
+            throw GpuServerException.INVALID_GPU_INFO.getException();
         }
 
         if (Objects.isNull(lab)) {
-            throw new GpuServerException("GpuServer의 Lab 정보는 Null일 수 없습니다.");
+            throw GpuServerException.INVALID_LAB_ID.getException();
         }
     }
 

--- a/back-end/src/main/java/admin/gpuserver/exception/DeleteHistoryException.java
+++ b/back-end/src/main/java/admin/gpuserver/exception/DeleteHistoryException.java
@@ -1,7 +1,18 @@
 package admin.gpuserver.exception;
 
-public class DeleteHistoryException extends RuntimeException {
-    public DeleteHistoryException(String message) {
-        super(message);
+import admin.exception.http.BadRequestException;
+import admin.exception.http.CustomException;
+
+public enum DeleteHistoryException {
+    INVALID_GPU_SERVER_ID(new BadRequestException("DeleteHistory의 GpuServer 정보는 Null일 수 없습니다."));
+
+    private CustomException customException;
+
+    DeleteHistoryException(CustomException e) {
+        this.customException = e;
+    }
+
+    public CustomException getException() {
+        return customException;
     }
 }

--- a/back-end/src/main/java/admin/gpuserver/exception/DeleteHistoryException.java
+++ b/back-end/src/main/java/admin/gpuserver/exception/DeleteHistoryException.java
@@ -4,6 +4,7 @@ import admin.exception.http.BadRequestException;
 import admin.exception.http.CustomException;
 
 public enum DeleteHistoryException {
+
     INVALID_GPU_SERVER_ID(new BadRequestException("DeleteHistory의 GpuServer 정보는 Null일 수 없습니다."));
 
     private CustomException customException;

--- a/back-end/src/main/java/admin/gpuserver/exception/GpuBoardException.java
+++ b/back-end/src/main/java/admin/gpuserver/exception/GpuBoardException.java
@@ -1,7 +1,21 @@
 package admin.gpuserver.exception;
 
-public class GpuBoardException extends RuntimeException {
-    public GpuBoardException(String message) {
-        super(message);
+import admin.exception.http.BadRequestException;
+import admin.exception.http.CustomException;
+
+public enum GpuBoardException{
+    INVALID_PERFORMANCE(new BadRequestException("잘못된 GpuBoard 정보 입력입니다.")),
+    INVALID_STATUS(new BadRequestException("GpuBoard 상태는 Null일 수 없습니다.")),
+    INVALID_MODEL(new BadRequestException("적절하지 않은 GpuBoard 모델 정보입니다.")),
+    INVALID_GPU_SERVER_ID(new BadRequestException("GpuBoard의 GpuServer 정보는 Null일 수 없습니다."));
+
+    private CustomException customException;
+
+    GpuBoardException(CustomException e) {
+        this.customException = e;
+    }
+
+    public CustomException getException() {
+        return customException;
     }
 }

--- a/back-end/src/main/java/admin/gpuserver/exception/GpuBoardException.java
+++ b/back-end/src/main/java/admin/gpuserver/exception/GpuBoardException.java
@@ -3,7 +3,7 @@ package admin.gpuserver.exception;
 import admin.exception.http.BadRequestException;
 import admin.exception.http.CustomException;
 
-public enum GpuBoardException{
+public enum GpuBoardException {
     INVALID_PERFORMANCE(new BadRequestException("잘못된 GpuBoard 정보 입력입니다.")),
     INVALID_STATUS(new BadRequestException("GpuBoard 상태는 Null일 수 없습니다.")),
     INVALID_MODEL(new BadRequestException("적절하지 않은 GpuBoard 모델 정보입니다.")),

--- a/back-end/src/main/java/admin/gpuserver/exception/GpuBoardException.java
+++ b/back-end/src/main/java/admin/gpuserver/exception/GpuBoardException.java
@@ -2,8 +2,10 @@ package admin.gpuserver.exception;
 
 import admin.exception.http.BadRequestException;
 import admin.exception.http.CustomException;
+import admin.exception.http.NotFoundException;
 
 public enum GpuBoardException {
+    GPU_BOARD_NOT_FOUND(new NotFoundException("존재하지 않는 보드입니다.")),
     INVALID_PERFORMANCE(new BadRequestException("잘못된 GpuBoard 정보 입력입니다.")),
     INVALID_STATUS(new BadRequestException("GpuBoard 상태는 Null일 수 없습니다.")),
     INVALID_MODEL(new BadRequestException("적절하지 않은 GpuBoard 모델 정보입니다.")),

--- a/back-end/src/main/java/admin/gpuserver/exception/GpuBoardException.java
+++ b/back-end/src/main/java/admin/gpuserver/exception/GpuBoardException.java
@@ -5,7 +5,9 @@ import admin.exception.http.CustomException;
 import admin.exception.http.NotFoundException;
 
 public enum GpuBoardException {
+
     GPU_BOARD_NOT_FOUND(new NotFoundException("존재하지 않는 보드입니다.")),
+
     INVALID_PERFORMANCE(new BadRequestException("잘못된 GpuBoard 정보 입력입니다.")),
     INVALID_STATUS(new BadRequestException("GpuBoard 상태는 Null일 수 없습니다.")),
     INVALID_MODEL(new BadRequestException("적절하지 않은 GpuBoard 모델 정보입니다.")),

--- a/back-end/src/main/java/admin/gpuserver/exception/GpuServerException.java
+++ b/back-end/src/main/java/admin/gpuserver/exception/GpuServerException.java
@@ -1,7 +1,24 @@
 package admin.gpuserver.exception;
 
-public class GpuServerException extends RuntimeException {
-    public GpuServerException(String message) {
-        super(message);
+import admin.exception.http.BadRequestException;
+import admin.exception.http.CustomException;
+import admin.exception.http.NotFoundException;
+
+public enum GpuServerException {
+    GPU_SERVER_NOT_FOUND(new NotFoundException("해당 id의 GPU 서버가 존재하지 않습니다.")),
+    GPU_BOARD_NOT_FOUND(new NotFoundException("존재하지 않는 보드입니다.")),
+    INVALID_NAME(new BadRequestException("적절한 GpuServer 이름이 아닙니다.")),
+    INVALID_STATUS(new BadRequestException("GpuServer의 상태는 Null일 수 없습니다.")),
+    INVALID_GPU_INFO(new BadRequestException("유효하지 않은 GpuServer 정보입니다.")),
+    INVALID_LAB_ID(new BadRequestException("GpuServer의 Lab 정보는 Null일 수 없습니다."));
+
+    private CustomException customException;
+
+    GpuServerException(CustomException e) {
+        this.customException = e;
+    }
+
+    public CustomException getException() {
+        return customException;
     }
 }

--- a/back-end/src/main/java/admin/gpuserver/exception/GpuServerException.java
+++ b/back-end/src/main/java/admin/gpuserver/exception/GpuServerException.java
@@ -6,7 +6,6 @@ import admin.exception.http.NotFoundException;
 
 public enum GpuServerException {
     GPU_SERVER_NOT_FOUND(new NotFoundException("해당 id의 GPU 서버가 존재하지 않습니다.")),
-    GPU_BOARD_NOT_FOUND(new NotFoundException("존재하지 않는 보드입니다.")),
     INVALID_NAME(new BadRequestException("적절한 GpuServer 이름이 아닙니다.")),
     INVALID_STATUS(new BadRequestException("GpuServer의 상태는 Null일 수 없습니다.")),
     INVALID_GPU_INFO(new BadRequestException("유효하지 않은 GpuServer 정보입니다.")),

--- a/back-end/src/main/java/admin/gpuserver/exception/GpuServerException.java
+++ b/back-end/src/main/java/admin/gpuserver/exception/GpuServerException.java
@@ -5,7 +5,9 @@ import admin.exception.http.CustomException;
 import admin.exception.http.NotFoundException;
 
 public enum GpuServerException {
+
     GPU_SERVER_NOT_FOUND(new NotFoundException("해당 id의 GPU 서버가 존재하지 않습니다.")),
+
     INVALID_NAME(new BadRequestException("적절한 GpuServer 이름이 아닙니다.")),
     INVALID_STATUS(new BadRequestException("GpuServer의 상태는 Null일 수 없습니다.")),
     INVALID_GPU_INFO(new BadRequestException("유효하지 않은 GpuServer 정보입니다.")),

--- a/back-end/src/main/java/admin/gpuserver/ui/GpuServerController.java
+++ b/back-end/src/main/java/admin/gpuserver/ui/GpuServerController.java
@@ -3,7 +3,7 @@ package admin.gpuserver.ui;
 import admin.gpuserver.application.GpuServerService;
 import admin.gpuserver.dto.request.GpuServerRequest;
 import admin.gpuserver.dto.request.GpuServerUpdateRequest;
-import admin.gpuserver.dto.response.ExceptionResponse;
+import admin.exception.dto.ExceptionResponse;
 import admin.gpuserver.dto.response.GpuServerResponse;
 import admin.gpuserver.dto.response.GpuServerResponses;
 import admin.gpuserver.exception.GpuServerException;

--- a/back-end/src/main/java/admin/gpuserver/ui/GpuServerController.java
+++ b/back-end/src/main/java/admin/gpuserver/ui/GpuServerController.java
@@ -57,11 +57,4 @@ public class GpuServerController {
 
         return ResponseEntity.noContent().build();
     }
-
-    @ExceptionHandler(GpuServerException.class)
-    public ResponseEntity<ExceptionResponse> handleException(GpuServerException e) {
-        ExceptionResponse exceptionResponse = ExceptionResponse.of(e.getMessage());
-
-        return ResponseEntity.badRequest().body(exceptionResponse);
-    }
 }

--- a/back-end/src/main/java/admin/gpuserver/ui/GpuServerController.java
+++ b/back-end/src/main/java/admin/gpuserver/ui/GpuServerController.java
@@ -1,12 +1,10 @@
 package admin.gpuserver.ui;
 
-import admin.exception.dto.ExceptionResponse;
 import admin.gpuserver.application.GpuServerService;
 import admin.gpuserver.dto.request.GpuServerRequest;
 import admin.gpuserver.dto.request.GpuServerUpdateRequest;
 import admin.gpuserver.dto.response.GpuServerResponse;
 import admin.gpuserver.dto.response.GpuServerResponses;
-import admin.gpuserver.exception.GpuServerException;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 

--- a/back-end/src/main/java/admin/gpuserver/ui/GpuServerController.java
+++ b/back-end/src/main/java/admin/gpuserver/ui/GpuServerController.java
@@ -1,9 +1,9 @@
 package admin.gpuserver.ui;
 
+import admin.exception.dto.ExceptionResponse;
 import admin.gpuserver.application.GpuServerService;
 import admin.gpuserver.dto.request.GpuServerRequest;
 import admin.gpuserver.dto.request.GpuServerUpdateRequest;
-import admin.exception.dto.ExceptionResponse;
 import admin.gpuserver.dto.response.GpuServerResponse;
 import admin.gpuserver.dto.response.GpuServerResponses;
 import admin.gpuserver.exception.GpuServerException;

--- a/back-end/src/main/java/admin/job/application/JobService.java
+++ b/back-end/src/main/java/admin/job/application/JobService.java
@@ -2,12 +2,15 @@ package admin.job.application;
 
 import admin.gpuserver.domain.GpuBoard;
 import admin.gpuserver.domain.repository.GpuBoardRepository;
+import admin.gpuserver.exception.GpuBoardException;
 import admin.job.domain.Job;
 import admin.job.domain.repository.JobRepository;
 import admin.job.dto.request.JobRequest;
 import admin.job.dto.response.JobResponse;
+import admin.job.exception.JobException;
 import admin.member.domain.Member;
 import admin.member.domain.repository.MemberRepository;
+import admin.member.exception.MemberException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -27,10 +30,10 @@ public class JobService {
     @Transactional
     public Long insert(Long memberId, JobRequest jobRequest) {
         GpuBoard gpuBoard = gpuBoardRepository.findByGpuServerId(jobRequest.getGpuServerId())
-                .orElseThrow(() -> new IllegalArgumentException("board 가 없습니다."));
+                .orElseThrow(GpuBoardException.GPU_BOARD_NOT_FOUND::getException);
 
         Member member = memberRepository.findById(memberId)
-                .orElseThrow(() -> new IllegalArgumentException("user 가 없습니다."));
+                .orElseThrow(MemberException.MEMBER_NOT_FOUND::getException);
 
         Job newJob = jobRepository.save(new Job(jobRequest.getName(), gpuBoard, member));
         gpuBoard.addJob(newJob);
@@ -48,7 +51,7 @@ public class JobService {
     @Transactional
     public void cancel(Long memberId, Long jobId) {
         Job job = jobRepository.findByIdAndMemberId(jobId, memberId)
-                .orElseThrow(() -> new IllegalArgumentException("job 이 없습니다."));
+                .orElseThrow(JobException.JOB_NOT_FOUND::getException);
 
         GpuBoard gpuBoard = job.getGpuBoard();
         gpuBoard.cancel(job);
@@ -56,6 +59,6 @@ public class JobService {
 
     private Job findJobById(Long id) {
         return jobRepository.findById(id)
-                .orElseThrow(() -> new IllegalArgumentException("job 이 없습니다."));
+                .orElseThrow(JobException.JOB_NOT_FOUND::getException);
     }
 }

--- a/back-end/src/main/java/admin/job/domain/Job.java
+++ b/back-end/src/main/java/admin/job/domain/Job.java
@@ -44,19 +44,19 @@ public class Job extends BaseEntity {
 
     private void validate(String name, JobStatus status, GpuBoard gpuBoard, Member member) {
         if (Objects.isNull(name) || name.isEmpty()) {
-            throw new JobException("적절한 Job 이름이 아닙니다.");
+            throw JobException.INVALID_JOB_NAME.getException();
         }
 
         if (Objects.isNull(status)) {
-            throw new JobException("Job 상태는 Null일 수 없습니다.");
+            throw JobException.INVALID_STATUS.getException();
         }
 
         if (Objects.isNull(gpuBoard)) {
-            throw new JobException("Job의 gpuBoard는 Null일 수 없습니다.");
+            throw JobException.INVALID_GPU_BOARD.getException();
         }
 
         if (Objects.isNull(member)) {
-            throw new JobException("Job의 Member는 Null일 수 없습니다.");
+            throw JobException.INVALID_MEMBER.getException();
         }
     }
 

--- a/back-end/src/main/java/admin/job/exception/JobException.java
+++ b/back-end/src/main/java/admin/job/exception/JobException.java
@@ -5,7 +5,9 @@ import admin.exception.http.CustomException;
 import admin.exception.http.NotFoundException;
 
 public enum JobException {
+
     JOB_NOT_FOUND(new NotFoundException("해당 id의 Job이 존재하지 않습니다.")),
+
     INVALID_JOB_NAME(new BadRequestException("적절한 Job 이름이 아닙니다.")),
     INVALID_STATUS(new BadRequestException("Job 상태는 Null일 수 없습니다.")),
     INVALID_GPU_BOARD(new BadRequestException("Job의 gpuBoard는 Null일 수 없습니다.")),

--- a/back-end/src/main/java/admin/job/exception/JobException.java
+++ b/back-end/src/main/java/admin/job/exception/JobException.java
@@ -1,7 +1,23 @@
 package admin.job.exception;
 
-public class JobException extends RuntimeException {
-    public JobException(String message) {
-        super(message);
+import admin.exception.http.BadRequestException;
+import admin.exception.http.CustomException;
+import admin.exception.http.NotFoundException;
+
+public enum JobException {
+    JOB_NOT_FOUND(new NotFoundException("해당 id의 Job이 존재하지 않습니다.")),
+    INVALID_JOB_NAME(new BadRequestException("적절한 Job 이름이 아닙니다.")),
+    INVALID_STATUS(new BadRequestException("Job 상태는 Null일 수 없습니다.")),
+    INVALID_GPU_BOARD(new BadRequestException("Job의 gpuBoard는 Null일 수 없습니다.")),
+    INVALID_MEMBER(new BadRequestException("Job의 Member는 Null일 수 없습니다."));
+
+    private CustomException customException;
+
+    JobException(CustomException e) {
+        this.customException = e;
+    }
+
+    public CustomException getException() {
+        return customException;
     }
 }

--- a/back-end/src/main/java/admin/lab/application/LabService.java
+++ b/back-end/src/main/java/admin/lab/application/LabService.java
@@ -52,6 +52,6 @@ public class LabService {
 
     private Lab findLabById(Long labId) {
         return labRepository.findById(labId)
-                .orElseThrow(() -> new LabException("해당 id의 Lab이 존재하지 않습니다."));
+                .orElseThrow(LabException.LAB_NOT_FOUND::getException);
     }
 }

--- a/back-end/src/main/java/admin/lab/domain/Lab.java
+++ b/back-end/src/main/java/admin/lab/domain/Lab.java
@@ -26,7 +26,7 @@ public class Lab extends BaseEntity {
 
     private void validate(String name) {
         if (Objects.isNull(name) || name.isEmpty()) {
-            throw new LabException("적절한 Lab 이름이 아닙니다.");
+            throw LabException.INVALID_LAB_NAME.getException();
         }
     }
 

--- a/back-end/src/main/java/admin/lab/exception/LabException.java
+++ b/back-end/src/main/java/admin/lab/exception/LabException.java
@@ -1,7 +1,19 @@
 package admin.lab.exception;
 
-public class LabException extends RuntimeException {
-    public LabException(String message) {
-        super(message);
+import admin.exception.BadRequestException;
+import admin.exception.CustomException;
+import admin.exception.NotFoundException;
+
+public enum LabException{
+    LAB_NOT_FOUND(new NotFoundException("해당 id의 Lab이 존재하지 않습니다.")),
+    INVALID_LAB_NAME(new BadRequestException("적절한 Lab 이름이 아닙니다."));
+
+    private CustomException customException;
+    LabException(CustomException e) {
+        this.customException = e;
+    }
+
+    public CustomException getException() {
+        return customException;
     }
 }

--- a/back-end/src/main/java/admin/lab/exception/LabException.java
+++ b/back-end/src/main/java/admin/lab/exception/LabException.java
@@ -5,7 +5,9 @@ import admin.exception.http.CustomException;
 import admin.exception.http.NotFoundException;
 
 public enum LabException {
+
     LAB_NOT_FOUND(new NotFoundException("해당 id의 Lab이 존재하지 않습니다.")),
+
     INVALID_LAB_NAME(new BadRequestException("적절한 Lab 이름이 아닙니다."));
 
     private CustomException customException;

--- a/back-end/src/main/java/admin/lab/exception/LabException.java
+++ b/back-end/src/main/java/admin/lab/exception/LabException.java
@@ -4,11 +4,12 @@ import admin.exception.BadRequestException;
 import admin.exception.CustomException;
 import admin.exception.NotFoundException;
 
-public enum LabException{
+public enum LabException {
     LAB_NOT_FOUND(new NotFoundException("해당 id의 Lab이 존재하지 않습니다.")),
     INVALID_LAB_NAME(new BadRequestException("적절한 Lab 이름이 아닙니다."));
 
     private CustomException customException;
+
     LabException(CustomException e) {
         this.customException = e;
     }

--- a/back-end/src/main/java/admin/lab/exception/LabException.java
+++ b/back-end/src/main/java/admin/lab/exception/LabException.java
@@ -1,8 +1,8 @@
 package admin.lab.exception;
 
-import admin.exception.BadRequestException;
-import admin.exception.CustomException;
-import admin.exception.NotFoundException;
+import admin.exception.http.BadRequestException;
+import admin.exception.http.CustomException;
+import admin.exception.http.NotFoundException;
 
 public enum LabException {
     LAB_NOT_FOUND(new NotFoundException("해당 id의 Lab이 존재하지 않습니다.")),

--- a/back-end/src/main/java/admin/lab/ui/LabController.java
+++ b/back-end/src/main/java/admin/lab/ui/LabController.java
@@ -1,11 +1,9 @@
 package admin.lab.ui;
 
-import admin.exception.dto.ExceptionResponse;
 import admin.lab.application.LabService;
 import admin.lab.dto.LabRequest;
 import admin.lab.dto.LabResponse;
 import admin.lab.dto.LabResponses;
-import admin.lab.exception.LabException;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 

--- a/back-end/src/main/java/admin/lab/ui/LabController.java
+++ b/back-end/src/main/java/admin/lab/ui/LabController.java
@@ -1,6 +1,6 @@
 package admin.lab.ui;
 
-import admin.gpuserver.dto.response.ExceptionResponse;
+import admin.exception.dto.ExceptionResponse;
 import admin.lab.application.LabService;
 import admin.lab.dto.LabRequest;
 import admin.lab.dto.LabResponse;
@@ -49,11 +49,5 @@ public class LabController {
     public ResponseEntity<Void> delete(@PathVariable Long labId) {
         labService.delete(labId);
         return ResponseEntity.noContent().build();
-    }
-
-    @ExceptionHandler(LabException.class)
-    public ResponseEntity<ExceptionResponse> handleException(LabException exception) {
-        ExceptionResponse exceptionResponse = ExceptionResponse.of(exception.getMessage());
-        return ResponseEntity.badRequest().body(exceptionResponse);
     }
 }

--- a/back-end/src/main/java/admin/member/application/MemberService.java
+++ b/back-end/src/main/java/admin/member/application/MemberService.java
@@ -2,6 +2,7 @@ package admin.member.application;
 
 import admin.lab.domain.Lab;
 import admin.lab.domain.repository.LabRepository;
+import admin.lab.exception.LabException;
 import admin.member.domain.Member;
 import admin.member.domain.MemberType;
 import admin.member.domain.repository.MemberRepository;
@@ -28,7 +29,7 @@ public class MemberService {
     @Transactional
     public Long createMember(MemberRequest request) {
         Lab lab = labRepository.findById(request.getLabId())
-                .orElseThrow(() -> new MemberException("해당 lab은 존재하지 않습니다."));
+                .orElseThrow(LabException.LAB_NOT_FOUND::getException);
         MemberType memberType = MemberType.ignoreCaseValueOf(request.getMemberType());
 
         Member member = new Member(request.getEmail(), request.getPassword(), request.getName(), memberType, lab);
@@ -64,7 +65,7 @@ public class MemberService {
         Member member = findMemberById(id);
 
         Lab updateLab = labRepository.findById(changeLabRequest.getLabId())
-                .orElseThrow(() -> new MemberException("해당 lab은 존재하지 않습니다."));
+                .orElseThrow(LabException.LAB_NOT_FOUND::getException);
         member.setLab(updateLab);
     }
 
@@ -76,6 +77,6 @@ public class MemberService {
 
     private Member findMemberById(Long id) {
         return memberRepository.findById(id)
-                .orElseThrow(() -> new MemberException("해당 id의 회원이 존재하지 않습니다."));
+                .orElseThrow(MemberException.MEMBER_NOT_FOUND::getException);
     }
 }

--- a/back-end/src/main/java/admin/member/domain/MemberType.java
+++ b/back-end/src/main/java/admin/member/domain/MemberType.java
@@ -1,6 +1,6 @@
 package admin.member.domain;
 
-import admin.member.exception.MemberTypeException;
+import admin.member.exception.MemberException;
 
 import java.util.Locale;
 
@@ -11,7 +11,7 @@ public enum MemberType {
         try {
             return MemberType.valueOf(input.toUpperCase(Locale.ROOT));
         } catch (IllegalArgumentException e) {
-            throw new MemberTypeException("존재하지 않는 MemberType 입니다.");
+            throw MemberException.INVALID_MEMBER_TYPE.getException();
         }
     }
 }

--- a/back-end/src/main/java/admin/member/exception/MemberException.java
+++ b/back-end/src/main/java/admin/member/exception/MemberException.java
@@ -1,7 +1,21 @@
 package admin.member.exception;
 
-public class MemberException extends RuntimeException {
-    public MemberException(String message) {
-        super(message);
+import admin.exception.BadRequestException;
+import admin.exception.CustomException;
+import admin.exception.NotFoundException;
+
+public enum MemberException {
+    MEMBER_NOT_FOUND(new NotFoundException("해당 id의 회원이 존재하지 않습니다.")),
+    INVALID_MEMBER_TYPE(new BadRequestException("존재하지 않는 MemberType 입니다."));
+
+    private CustomException customException;
+
+    MemberException(CustomException e) {
+        this.customException = e;
     }
+
+    public CustomException getException() {
+        return customException;
+    }
+
 }

--- a/back-end/src/main/java/admin/member/exception/MemberException.java
+++ b/back-end/src/main/java/admin/member/exception/MemberException.java
@@ -5,7 +5,9 @@ import admin.exception.http.CustomException;
 import admin.exception.http.NotFoundException;
 
 public enum MemberException {
+
     MEMBER_NOT_FOUND(new NotFoundException("해당 id의 회원이 존재하지 않습니다.")),
+
     INVALID_MEMBER_TYPE(new BadRequestException("존재하지 않는 MemberType 입니다."));
 
     private CustomException customException;

--- a/back-end/src/main/java/admin/member/exception/MemberException.java
+++ b/back-end/src/main/java/admin/member/exception/MemberException.java
@@ -1,8 +1,8 @@
 package admin.member.exception;
 
-import admin.exception.BadRequestException;
-import admin.exception.CustomException;
-import admin.exception.NotFoundException;
+import admin.exception.http.BadRequestException;
+import admin.exception.http.CustomException;
+import admin.exception.http.NotFoundException;
 
 public enum MemberException {
     MEMBER_NOT_FOUND(new NotFoundException("해당 id의 회원이 존재하지 않습니다.")),

--- a/back-end/src/main/java/admin/member/exception/MemberTypeException.java
+++ b/back-end/src/main/java/admin/member/exception/MemberTypeException.java
@@ -1,7 +1,0 @@
-package admin.member.exception;
-
-public class MemberTypeException extends RuntimeException {
-    public MemberTypeException(String message) {
-        super(message);
-    }
-}

--- a/back-end/src/main/java/admin/member/ui/MemberController.java
+++ b/back-end/src/main/java/admin/member/ui/MemberController.java
@@ -1,6 +1,6 @@
 package admin.member.ui;
 
-import admin.gpuserver.dto.response.ExceptionResponse;
+import admin.exception.dto.ExceptionResponse;
 import admin.member.application.MemberService;
 import admin.member.dto.request.ChangeLabRequest;
 import admin.member.dto.request.MemberInfoRequest;

--- a/back-end/src/main/java/admin/member/ui/MemberController.java
+++ b/back-end/src/main/java/admin/member/ui/MemberController.java
@@ -1,14 +1,11 @@
 package admin.member.ui;
 
-import admin.exception.dto.ExceptionResponse;
 import admin.member.application.MemberService;
 import admin.member.dto.request.ChangeLabRequest;
 import admin.member.dto.request.MemberInfoRequest;
 import admin.member.dto.request.MemberRequest;
 import admin.member.dto.request.MemberTypeRequest;
 import admin.member.dto.response.MemberResponse;
-import admin.member.exception.MemberException;
-import admin.member.exception.MemberTypeException;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -58,11 +55,5 @@ public class MemberController {
     public ResponseEntity<Void> deleteMember(@PathVariable Long id) {
         memberService.deleteMember(id);
         return ResponseEntity.noContent().build();
-    }
-
-    @ExceptionHandler({MemberException.class, MemberTypeException.class})
-    public ResponseEntity<ExceptionResponse> handleException(RuntimeException exception) {
-        ExceptionResponse exceptionResponse = ExceptionResponse.of(exception.getMessage());
-        return ResponseEntity.badRequest().body(exceptionResponse);
     }
 }

--- a/back-end/src/test/java/admin/gpuserver/domain/DeleteHistoryTest.java
+++ b/back-end/src/test/java/admin/gpuserver/domain/DeleteHistoryTest.java
@@ -29,7 +29,6 @@ public class DeleteHistoryTest {
     @Test
     void 생성_GpuServer_null() {
         assertThatThrownBy(() -> new DeleteHistory(null))
-                .isInstanceOf(DeleteHistoryException.class)
-                .hasMessage("DeleteHistory의 GpuServer 정보는 Null일 수 없습니다.");
+                .isEqualTo(DeleteHistoryException.INVALID_GPU_SERVER_ID.getException());
     }
 }

--- a/back-end/src/test/java/admin/gpuserver/domain/GpuBoardTest.java
+++ b/back-end/src/test/java/admin/gpuserver/domain/GpuBoardTest.java
@@ -31,16 +31,14 @@ public class GpuBoardTest {
     @Test
     void 생성_IsWorking_null() {
         assertThatThrownBy(() -> new GpuBoard(null, 1000L, "모델1", gpuServer))
-                .isInstanceOf(GpuBoardException.class)
-                .hasMessage("GpuBoard 상태는 Null일 수 없습니다.");
+                .isEqualTo(GpuBoardException.INVALID_STATUS.getException());
     }
 
     @DisplayName("생성 테스트 - Performance가 null")
     @Test
     void 생성_Performance_null() {
         assertThatThrownBy(() -> new GpuBoard(false, null, "모델1", gpuServer))
-                .isInstanceOf(GpuBoardException.class)
-                .hasMessage("잘못된 GpuBoard 정보 입력입니다.");
+                .isEqualTo(GpuBoardException.INVALID_PERFORMANCE.getException());
     }
 
     @DisplayName("생성 테스트 - Performance가 0이하")
@@ -48,31 +46,27 @@ public class GpuBoardTest {
     @ValueSource(longs = {-1024, -1, 0})
     void 생성_Performance_0이하(Long input) {
         assertThatThrownBy(() -> new GpuBoard(false, input, "모델1", gpuServer))
-                .isInstanceOf(GpuBoardException.class)
-                .hasMessage("잘못된 GpuBoard 정보 입력입니다.");
+                .isEqualTo(GpuBoardException.INVALID_PERFORMANCE.getException());
     }
 
     @DisplayName("생성 테스트 - 모델이름이 null")
     @Test
     void 생성_모델이름_null() {
         assertThatThrownBy(() -> new GpuBoard(false, 1000L, null, gpuServer))
-                .isInstanceOf(GpuBoardException.class)
-                .hasMessage("적절하지 않은 GpuBoard 이름 정보입니다.");
+                .isEqualTo(GpuBoardException.INVALID_MODEL.getException());
     }
 
     @DisplayName("생성 테스트 - 모델이름이 빈문자열")
     @Test
     void 생성_모델이름_빈문자열() {
         assertThatThrownBy(() -> new GpuBoard(false, 1000L, "", gpuServer))
-                .isInstanceOf(GpuBoardException.class)
-                .hasMessage("적절하지 않은 GpuBoard 이름 정보입니다.");
+                .isEqualTo(GpuBoardException.INVALID_MODEL.getException());
     }
 
     @DisplayName("생성 테스트 - GpuServer가 null")
     @Test
     void 생성_GpuServer_null() {
         assertThatThrownBy(() -> new GpuBoard(false, 1000L, "모델1", null))
-                .isInstanceOf(GpuBoardException.class)
-                .hasMessage("GpuBoard의 GpuServer 정보는 Null일 수 없습니다.");
+                .isEqualTo(GpuBoardException.INVALID_GPU_SERVER_ID.getException());
     }
 }

--- a/back-end/src/test/java/admin/gpuserver/domain/GpuServerTest.java
+++ b/back-end/src/test/java/admin/gpuserver/domain/GpuServerTest.java
@@ -30,32 +30,28 @@ public class GpuServerTest {
     @Test
     void 생성_이름_null() {
         assertThatThrownBy(() -> new GpuServer(null, false, 1024L, 1024L, lab))
-                .isInstanceOf(GpuServerException.class)
-                .hasMessage("적절한 GpuServer 이름이 아닙니다.");
+                .isEqualTo(GpuServerException.INVALID_NAME.getException());
     }
 
     @DisplayName("생성 테스트 - 이름이 빈문자열")
     @Test
     void 생성_이름_빈문자열() {
         assertThatThrownBy(() -> new GpuServer("", false, 1024L, 1024L, lab))
-                .isInstanceOf(GpuServerException.class)
-                .hasMessage("적절한 GpuServer 이름이 아닙니다.");
+                .isEqualTo(GpuServerException.INVALID_NAME.getException());
     }
 
     @DisplayName("생성 테스트 - IsOn이 null")
     @Test
     void 생성_IsOn_null() {
         assertThatThrownBy(() -> new GpuServer("GPU서버1", null, 1024L, 1024L, lab))
-                .isInstanceOf(GpuServerException.class)
-                .hasMessage("GpuServer의 상태는 Null일 수 없습니다.");
+                .isEqualTo(GpuServerException.INVALID_STATUS.getException());
     }
 
     @DisplayName("생성 테스트 - MemorySize이 null")
     @Test
     void 생성_MemorySize_null() {
         assertThatThrownBy(() -> new GpuServer("GPU서버1", false, null, 1024L, lab))
-                .isInstanceOf(GpuServerException.class)
-                .hasMessage("유효하지 않은 GpuServer 정보입니다.");
+                .isEqualTo(GpuServerException.INVALID_GPU_INFO.getException());
     }
 
     @DisplayName("생성 테스트 - MemorySize이 0이하")
@@ -63,16 +59,14 @@ public class GpuServerTest {
     @ValueSource(longs = {-1024, -1, 0})
     void 생성_MemorySize_0이하(Long input) {
         assertThatThrownBy(() -> new GpuServer("GPU서버1", false, input, 1024L, lab))
-                .isInstanceOf(GpuServerException.class)
-                .hasMessage("유효하지 않은 GpuServer 정보입니다.");
+                .isEqualTo(GpuServerException.INVALID_GPU_INFO.getException());
     }
 
     @DisplayName("생성 테스트 - DiskSize이 null")
     @Test
     void 생성_DiskSize_null() {
         assertThatThrownBy(() -> new GpuServer("GPU서버1", false, 1024L, null, lab))
-                .isInstanceOf(GpuServerException.class)
-                .hasMessage("유효하지 않은 GpuServer 정보입니다.");
+                .isEqualTo(GpuServerException.INVALID_GPU_INFO.getException());
     }
 
     @DisplayName("생성 테스트 - DiskSize이 0이하")
@@ -80,15 +74,13 @@ public class GpuServerTest {
     @ValueSource(longs = {-1024, -1, 0})
     void 생성_DiskSize_0이하(Long input) {
         assertThatThrownBy(() -> new GpuServer("GPU서버1", false, 1024L, input, lab))
-                .isInstanceOf(GpuServerException.class)
-                .hasMessage("유효하지 않은 GpuServer 정보입니다.");
+                .isEqualTo(GpuServerException.INVALID_GPU_INFO.getException());
     }
 
     @DisplayName("생성 테스트 - Lab이 null")
     @Test
     void 생성_Lab_null() {
         assertThatThrownBy(() -> new GpuServer("GPU서버1", false, 1024L, 1024L, null))
-                .isInstanceOf(GpuServerException.class)
-                .hasMessage("GpuServer의 Lab 정보는 Null일 수 없습니다.");
+                .isEqualTo(GpuServerException.INVALID_LAB_ID.getException());
     }
 }

--- a/back-end/src/test/java/admin/gpuserver/domain/repository/GpuServerRepositoryTest.java
+++ b/back-end/src/test/java/admin/gpuserver/domain/repository/GpuServerRepositoryTest.java
@@ -48,7 +48,8 @@ public class GpuServerRepositoryTest {
 
         em.clear();
 
-        GpuServer persistGpuServer = gpuServerRepository.findById(gpuServer.getId()).orElseThrow(IllegalArgumentException::new);
+        GpuServer persistGpuServer = gpuServerRepository.findById(gpuServer.getId())
+                .orElseThrow(IllegalArgumentException::new);
         Assertions.assertThat(persistGpuServer.getLab()).isNotNull();
         assertThat(persistGpuServer.getCreatedAt()).isNotNull();
     }

--- a/back-end/src/test/java/admin/gpuserver/ui/GpuServerAcceptanceTest.java
+++ b/back-end/src/test/java/admin/gpuserver/ui/GpuServerAcceptanceTest.java
@@ -130,7 +130,8 @@ public class GpuServerAcceptanceTest extends AcceptanceTest {
         ExtractableResponse<Response> response = GpuServer_전체조회();
 
         assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
-        assertThat(response.jsonPath().getList("gpuServers", GpuServerResponse.class)).hasSize(dummyGpuServerIds.size());
+        assertThat(response.jsonPath().getList("gpuServers", GpuServerResponse.class))
+                .hasSize(dummyGpuServerIds.size());
     }
 
     @DisplayName("GpuServer 생성")

--- a/back-end/src/test/java/admin/job/application/JobServiceTest.java
+++ b/back-end/src/test/java/admin/job/application/JobServiceTest.java
@@ -4,13 +4,16 @@ import admin.gpuserver.domain.GpuBoard;
 import admin.gpuserver.domain.GpuServer;
 import admin.gpuserver.domain.repository.GpuBoardRepository;
 import admin.gpuserver.domain.repository.GpuServerRepository;
+import admin.gpuserver.exception.GpuBoardException;
 import admin.job.dto.request.JobRequest;
 import admin.job.dto.response.JobResponse;
+import admin.job.exception.JobException;
 import admin.lab.domain.Lab;
 import admin.lab.domain.repository.LabRepository;
 import admin.member.domain.Member;
 import admin.member.domain.MemberType;
 import admin.member.domain.repository.MemberRepository;
+import admin.member.exception.MemberException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -66,8 +69,7 @@ class JobServiceTest {
         JobRequest jobRequest = new JobRequest(server.getId(), "job", "metadata", "12");
 
         assertThatThrownBy(() -> jobService.insert(notExistingMemberId, jobRequest))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("user 가 없습니다.");
+                .isEqualTo(MemberException.MEMBER_NOT_FOUND.getException());
     }
 
     @Test
@@ -77,8 +79,7 @@ class JobServiceTest {
         JobRequest jobRequest = new JobRequest(notExistingServerId, "job", "metadata", "12");
 
         assertThatThrownBy(() -> jobService.insert(member.getId(), jobRequest))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("board 가 없습니다.");
+                .isEqualTo(GpuBoardException.GPU_BOARD_NOT_FOUND.getException());
     }
 
     @Test
@@ -97,7 +98,6 @@ class JobServiceTest {
         Long notExistingJobId = Long.MAX_VALUE;
 
         assertThatThrownBy(() -> jobService.findById(notExistingJobId))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("job 이 없습니다.");
+                .isEqualTo(JobException.JOB_NOT_FOUND.getException());
     }
 }

--- a/back-end/src/test/java/admin/job/domain/JobTest.java
+++ b/back-end/src/test/java/admin/job/domain/JobTest.java
@@ -36,39 +36,34 @@ public class JobTest {
     @Test
     void 생성_이름_null() {
         assertThatThrownBy(() -> new Job(null, JobStatus.WAITING, gpuBoard, member))
-                .isInstanceOf(JobException.class)
-                .hasMessage("적절한 Job 이름이 아닙니다.");
+                .isEqualTo(JobException.INVALID_JOB_NAME.getException());
     }
 
     @DisplayName("생성 테스트 - 이름이 빈문자열")
     @Test
     void 생성_이름_빈문자열() {
         assertThatThrownBy(() -> new Job("", JobStatus.WAITING, gpuBoard, member))
-                .isInstanceOf(JobException.class)
-                .hasMessage("적절한 Job 이름이 아닙니다.");
+                .isEqualTo(JobException.INVALID_JOB_NAME.getException());
     }
 
     @DisplayName("생성 테스트 - JobStatus가 null")
     @Test
     void 생성_JobStatus_null() {
         assertThatThrownBy(() -> new Job("잡1", null, gpuBoard, member))
-                .isInstanceOf(JobException.class)
-                .hasMessage("Job 상태는 Null일 수 없습니다.");
+                .isEqualTo(JobException.INVALID_STATUS.getException());
     }
 
     @DisplayName("생성 테스트 - GpuBoard가 null")
     @Test
     void 생성_GpuBoard_null() {
         assertThatThrownBy(() -> new Job("잡1", JobStatus.WAITING, null, member))
-                .isInstanceOf(JobException.class)
-                .hasMessage("Job의 gpuBoard는 Null일 수 없습니다.");
+                .isEqualTo(JobException.INVALID_GPU_BOARD.getException());
     }
 
     @DisplayName("생성 테스트 - Member가 null")
     @Test
     void 생성_Member_null() {
         assertThatThrownBy(() -> new Job("잡1", JobStatus.WAITING, gpuBoard, null))
-                .isInstanceOf(JobException.class)
-                .hasMessage("Job의 Member는 Null일 수 없습니다.");
+                .isEqualTo(JobException.INVALID_MEMBER.getException());
     }
 }

--- a/back-end/src/test/java/admin/job/ui/JobAcceptanceTest.java
+++ b/back-end/src/test/java/admin/job/ui/JobAcceptanceTest.java
@@ -3,8 +3,6 @@ package admin.job.ui;
 import admin.AcceptanceTest;
 import org.junit.jupiter.api.BeforeEach;
 
-import static org.junit.jupiter.api.Assertions.*;
-
 class JobAcceptanceTest extends AcceptanceTest {
     @Override
     @BeforeEach

--- a/back-end/src/test/java/admin/job/ui/JobAcceptanceTest.java
+++ b/back-end/src/test/java/admin/job/ui/JobAcceptanceTest.java
@@ -1,0 +1,16 @@
+package admin.job.ui;
+
+import admin.AcceptanceTest;
+import org.junit.jupiter.api.BeforeEach;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class JobAcceptanceTest extends AcceptanceTest {
+    @Override
+    @BeforeEach
+    public void setUp() {
+        super.setUp();
+    }
+
+
+}

--- a/back-end/src/test/java/admin/lab/application/LabServiceTest.java
+++ b/back-end/src/test/java/admin/lab/application/LabServiceTest.java
@@ -46,7 +46,7 @@ class LabServiceTest {
         Long notExistingId = Long.MAX_VALUE;
 
         assertThatThrownBy(() -> labService.findById(notExistingId))
-                .isInstanceOf(LabException.LAB_NOT_FOUND.getException().getClass());
+                .isEqualTo(LabException.LAB_NOT_FOUND.getException());
     }
 
     @Test
@@ -89,7 +89,7 @@ class LabServiceTest {
         LabRequest labRequestToUpdate = new LabRequest("updateLabName");
 
         assertThatThrownBy(() -> labService.update(notExistingId, labRequestToUpdate))
-                .isInstanceOf(LabException.LAB_NOT_FOUND.getException().getClass());
+                .isEqualTo(LabException.LAB_NOT_FOUND.getException());
     }
 
     @Test
@@ -101,7 +101,7 @@ class LabServiceTest {
         labService.delete(createdId);
 
         assertThatThrownBy(() -> labService.findById(createdId))
-                .isInstanceOf(LabException.LAB_NOT_FOUND.getException().getClass());
+                .isEqualTo(LabException.LAB_NOT_FOUND.getException());
     }
 
     @Test
@@ -110,6 +110,6 @@ class LabServiceTest {
         Long notExistingId = Long.MAX_VALUE;
 
         assertThatThrownBy(() -> labService.delete(notExistingId))
-                .isInstanceOf(LabException.LAB_NOT_FOUND.getException().getClass());
+                .isEqualTo(LabException.LAB_NOT_FOUND.getException());
     }
 }

--- a/back-end/src/test/java/admin/lab/application/LabServiceTest.java
+++ b/back-end/src/test/java/admin/lab/application/LabServiceTest.java
@@ -46,8 +46,7 @@ class LabServiceTest {
         Long notExistingId = Long.MAX_VALUE;
 
         assertThatThrownBy(() -> labService.findById(notExistingId))
-                .isInstanceOf(LabException.class)
-                .hasMessage("해당 id의 Lab이 존재하지 않습니다.");
+                .isInstanceOf(LabException.LAB_NOT_FOUND.getException().getClass());
     }
 
     @Test
@@ -62,14 +61,12 @@ class LabServiceTest {
     @DisplayName("생성 후 전체 조회")
     void createAndFindAll() {
         LabResponses beforeLabResponses = labService.findAll();
-        int beforeSize = beforeLabResponses.getLabResponses()
-                .size();
+        int beforeSize = beforeLabResponses.getLabResponses().size();
 
         labService.save(LAB_REQUEST);
 
         LabResponses afterLabResponses = labService.findAll();
-        int afterSize = afterLabResponses.getLabResponses()
-                .size();
+        int afterSize = afterLabResponses.getLabResponses().size();
         assertThat(afterSize).isEqualTo(beforeSize + 1);
     }
 
@@ -92,8 +89,7 @@ class LabServiceTest {
         LabRequest labRequestToUpdate = new LabRequest("updateLabName");
 
         assertThatThrownBy(() -> labService.update(notExistingId, labRequestToUpdate))
-                .isInstanceOf(LabException.class)
-                .hasMessage("해당 id의 Lab이 존재하지 않습니다.");
+                .isInstanceOf(LabException.LAB_NOT_FOUND.getException().getClass());
     }
 
     @Test
@@ -105,8 +101,7 @@ class LabServiceTest {
         labService.delete(createdId);
 
         assertThatThrownBy(() -> labService.findById(createdId))
-                .isInstanceOf(LabException.class)
-                .hasMessage("해당 id의 Lab이 존재하지 않습니다.");
+                .isInstanceOf(LabException.LAB_NOT_FOUND.getException().getClass());
     }
 
     @Test
@@ -115,7 +110,6 @@ class LabServiceTest {
         Long notExistingId = Long.MAX_VALUE;
 
         assertThatThrownBy(() -> labService.delete(notExistingId))
-                .isInstanceOf(LabException.class)
-                .hasMessage("해당 id의 Lab이 존재하지 않습니다.");
+                .isInstanceOf(LabException.LAB_NOT_FOUND.getException().getClass());
     }
 }

--- a/back-end/src/test/java/admin/lab/domain/LabTest.java
+++ b/back-end/src/test/java/admin/lab/domain/LabTest.java
@@ -19,15 +19,13 @@ public class LabTest {
     @Test
     void 생성_이름_null() {
         assertThatThrownBy(() -> new Lab(null))
-                .isInstanceOf(LabException.class)
-                .hasMessage("적절한 Lab 이름이 아닙니다.");
+                .isInstanceOf(LabException.INVALID_LAB_NAME.getException().getClass());
     }
 
     @DisplayName("생성 테스트 - 이름이 빈문자열")
     @Test
     void 생성_이름_빈문자열() {
         assertThatThrownBy(() -> new Lab(""))
-                .isInstanceOf(LabException.class)
-                .hasMessage("적절한 Lab 이름이 아닙니다.");
+                .isInstanceOf(LabException.INVALID_LAB_NAME.getException().getClass());
     }
 }

--- a/back-end/src/test/java/admin/lab/domain/LabTest.java
+++ b/back-end/src/test/java/admin/lab/domain/LabTest.java
@@ -19,13 +19,13 @@ public class LabTest {
     @Test
     void 생성_이름_null() {
         assertThatThrownBy(() -> new Lab(null))
-                .isInstanceOf(LabException.INVALID_LAB_NAME.getException().getClass());
+                .isEqualTo(LabException.INVALID_LAB_NAME.getException());
     }
 
     @DisplayName("생성 테스트 - 이름이 빈문자열")
     @Test
     void 생성_이름_빈문자열() {
         assertThatThrownBy(() -> new Lab(""))
-                .isInstanceOf(LabException.INVALID_LAB_NAME.getException().getClass());
+                .isEqualTo(LabException.INVALID_LAB_NAME.getException());
     }
 }

--- a/back-end/src/test/java/admin/member/application/MemberServiceTest.java
+++ b/back-end/src/test/java/admin/member/application/MemberServiceTest.java
@@ -2,6 +2,7 @@ package admin.member.application;
 
 import admin.lab.application.LabService;
 import admin.lab.dto.LabRequest;
+import admin.lab.exception.LabException;
 import admin.member.domain.MemberType;
 import admin.member.dto.request.ChangeLabRequest;
 import admin.member.dto.request.MemberInfoRequest;
@@ -9,7 +10,6 @@ import admin.member.dto.request.MemberRequest;
 import admin.member.dto.request.MemberTypeRequest;
 import admin.member.dto.response.MemberResponse;
 import admin.member.exception.MemberException;
-import admin.member.exception.MemberTypeException;
 import org.assertj.core.api.AbstractThrowableAssert;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -57,7 +57,8 @@ class MemberServiceTest {
         assertThat(response.getId()).isEqualTo(createdId);
         assertThat(response.getEmail()).isEqualTo(memberRequest.getEmail());
         assertThat(response.getName()).isEqualTo(memberRequest.getName());
-        Assertions.assertThat(response.getMemberType()).isEqualTo(MemberType.ignoreCaseValueOf(memberRequest.getMemberType()));
+        Assertions.assertThat(response.getMemberType())
+                .isEqualTo(MemberType.ignoreCaseValueOf(memberRequest.getMemberType()));
         assertThat(response.getLabResponse()
                 .getId()).isEqualTo(memberRequest.getLabId());
     }
@@ -67,8 +68,8 @@ class MemberServiceTest {
     void findNotExistingMember() {
         Long notExistingId = Long.MAX_VALUE;
 
-        assertThatThrownBy(() -> memberService.findMember(notExistingId)).isInstanceOf(MemberException.class)
-                .hasMessage("해당 id의 회원이 존재하지 않습니다.");
+        assertThatThrownBy(() -> memberService.findMember(notExistingId))
+                .isInstanceOf(MemberException.MEMBER_NOT_FOUND.getException().getClass());
     }
 
     @Test
@@ -112,7 +113,8 @@ class MemberServiceTest {
         Long notExistingMemberId = Long.MAX_VALUE;
         MemberTypeRequest memberTypeRequest = new MemberTypeRequest("USER");
 
-        Throwable throwable = catchThrowable(() -> memberService.updateMemberType(notExistingMemberId, memberTypeRequest));
+        Throwable throwable = catchThrowable(() -> memberService
+                .updateMemberType(notExistingMemberId, memberTypeRequest));
         존재하지_않는_회원_요청_에러_발생(throwable);
     }
 
@@ -123,8 +125,7 @@ class MemberServiceTest {
         MemberTypeRequest notMemberType = new MemberTypeRequest("NOT_MEMBER_TYPE");
 
         assertThatThrownBy(() -> memberService.updateMemberType(createdId, notMemberType))
-                .isInstanceOf(MemberTypeException.class)
-                .hasMessage("존재하지 않는 MemberType 입니다.");
+                .isInstanceOf(MemberException.INVALID_MEMBER_TYPE.getException().getClass());
     }
 
     @Test
@@ -159,8 +160,8 @@ class MemberServiceTest {
         Long notExistingLabId = Long.MAX_VALUE;
         ChangeLabRequest changeLabRequest = new ChangeLabRequest(notExistingLabId);
 
-        assertThatThrownBy(() -> memberService.changeLab(createdId, changeLabRequest)).isInstanceOf(MemberException.class)
-                .hasMessage("해당 lab은 존재하지 않습니다.");
+        assertThatThrownBy(() -> memberService.changeLab(createdId, changeLabRequest))
+                .isInstanceOf(LabException.LAB_NOT_FOUND.getException().getClass());
     }
 
     @Test
@@ -186,7 +187,6 @@ class MemberServiceTest {
 
     private AbstractThrowableAssert<?, ? extends Throwable> 존재하지_않는_회원_요청_에러_발생(Throwable throwable) {
         return assertThat(throwable)
-                .isInstanceOf(MemberException.class)
-                .hasMessage("해당 id의 회원이 존재하지 않습니다.");
+                .isInstanceOf(MemberException.MEMBER_NOT_FOUND.getException().getClass());
     }
 }

--- a/back-end/src/test/java/admin/member/application/MemberServiceTest.java
+++ b/back-end/src/test/java/admin/member/application/MemberServiceTest.java
@@ -69,7 +69,7 @@ class MemberServiceTest {
         Long notExistingId = Long.MAX_VALUE;
 
         assertThatThrownBy(() -> memberService.findMember(notExistingId))
-                .isInstanceOf(MemberException.MEMBER_NOT_FOUND.getException().getClass());
+                .isEqualTo(MemberException.MEMBER_NOT_FOUND.getException());
     }
 
     @Test
@@ -125,7 +125,7 @@ class MemberServiceTest {
         MemberTypeRequest notMemberType = new MemberTypeRequest("NOT_MEMBER_TYPE");
 
         assertThatThrownBy(() -> memberService.updateMemberType(createdId, notMemberType))
-                .isInstanceOf(MemberException.INVALID_MEMBER_TYPE.getException().getClass());
+                .isEqualTo(MemberException.INVALID_MEMBER_TYPE.getException());
     }
 
     @Test
@@ -161,7 +161,7 @@ class MemberServiceTest {
         ChangeLabRequest changeLabRequest = new ChangeLabRequest(notExistingLabId);
 
         assertThatThrownBy(() -> memberService.changeLab(createdId, changeLabRequest))
-                .isInstanceOf(LabException.LAB_NOT_FOUND.getException().getClass());
+                .isEqualTo(LabException.LAB_NOT_FOUND.getException());
     }
 
     @Test
@@ -187,6 +187,6 @@ class MemberServiceTest {
 
     private AbstractThrowableAssert<?, ? extends Throwable> 존재하지_않는_회원_요청_에러_발생(Throwable throwable) {
         return assertThat(throwable)
-                .isInstanceOf(MemberException.MEMBER_NOT_FOUND.getException().getClass());
+                .isEqualTo(MemberException.MEMBER_NOT_FOUND.getException());
     }
 }

--- a/back-end/src/test/java/admin/member/domain/MemberTypeTest.java
+++ b/back-end/src/test/java/admin/member/domain/MemberTypeTest.java
@@ -28,6 +28,6 @@ class MemberTypeTest {
     @DisplayName("존재하지 않는 타입 검색시 에러 발생")
     void notExistingTypeTest() {
         assertThatThrownBy(() -> MemberType.ignoreCaseValueOf("notMemberType"))
-                .isInstanceOf(MemberException.INVALID_MEMBER_TYPE.getException().getClass());
+                .isEqualTo(MemberException.INVALID_MEMBER_TYPE.getException());
     }
 }

--- a/back-end/src/test/java/admin/member/domain/MemberTypeTest.java
+++ b/back-end/src/test/java/admin/member/domain/MemberTypeTest.java
@@ -1,6 +1,6 @@
 package admin.member.domain;
 
-import admin.member.exception.MemberTypeException;
+import admin.member.exception.MemberException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -27,6 +27,7 @@ class MemberTypeTest {
     @Test
     @DisplayName("존재하지 않는 타입 검색시 에러 발생")
     void notExistingTypeTest() {
-        assertThatThrownBy(() -> MemberType.ignoreCaseValueOf("notMemberType")).isInstanceOf(MemberTypeException.class);
+        assertThatThrownBy(() -> MemberType.ignoreCaseValueOf("notMemberType"))
+                .isInstanceOf(MemberException.INVALID_MEMBER_TYPE.getException().getClass());
     }
 }

--- a/back-end/src/test/java/admin/member/ui/MemberAcceptanceTest.java
+++ b/back-end/src/test/java/admin/member/ui/MemberAcceptanceTest.java
@@ -184,7 +184,7 @@ class MemberAcceptanceTest extends AcceptanceTest {
         assertThat(response.statusCode()).isEqualTo(HttpStatus.NO_CONTENT.value());
 
         ExtractableResponse<Response> searchResponse = MEMBER_조회_요청(id);
-        assertThat(searchResponse.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
+        assertThat(searchResponse.statusCode()).isEqualTo(HttpStatus.NOT_FOUND.value());
     }
 
     private void MEMBER_정상_생성됨(ExtractableResponse<Response> response) {


### PR DESCRIPTION
![Screenshot from 2021-07-18 14-31-59](https://user-images.githubusercontent.com/49307266/126056883-300a7bd8-ac00-4d57-9b76-06c2431d8acc.png)
> 현재는 2가지만 만든 상태고, 상태코드가 추가되면 더 추가할 생각입니다.


기본 계층 구조를 다음과 같이 잡고, Exception 별로 Contoller Advice를 타도록 구성해봤습니다.
```java
public class ControllerAdvice {
    @ExceptionHandler(BadRequestException.class)
    public ResponseEntity<ExceptionResponse> badRequestHandle(BadRequestException exception) {
        ExceptionResponse response = ExceptionResponse.of(exception.getMessage());
        return ResponseEntity.badRequest().body(response);
    }

    @ExceptionHandler(NotFoundException.class)
    public ResponseEntity<ExceptionResponse> notFoundHandle(NotFoundException exception) {
        ExceptionResponse response = ExceptionResponse.of(exception.getMessage());
        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(response);
    }

    @ExceptionHandler(Exception.class)
    public ResponseEntity<ExceptionResponse> globalHandle(Exception exception) {
        logger.error("Unhandled Exception", exception);

        ExceptionResponse response = ExceptionResponse.of(exception.getMessage());
        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(response);
    }
```

각각 패키지별로(job, gpuserver, member, lab) 구성은 enum으로 관리를 쉽게 해보도록 구성해봤습니다.
```java
public enum LabException {
    LAB_NOT_FOUND(new NotFoundException("해당 id의 Lab이 존재하지 않습니다.")),
    INVALID_LAB_NAME(new BadRequestException("적절한 Lab 이름이 아닙니다."));

    private CustomException customException;

    LabException(CustomException e) {
        this.customException = e;
    }

    public CustomException getException() {
        return customException;
    }
}
```

enum 에서 각각의 요청의 상태코드를 관리할 수 있다는 장점, 여러개의  ExceptionHandler를 만들지 않아도 된다는게 또 하나의 장점이라 생각합니다.

테스트 코드의 검증도 매번 message를 비교해주지 않고
```java
        assertThatThrownBy(() -> new Lab(null))
                .isEqualTo(LabException.INVALID_LAB_NAME.getException());
```
직접 Exception의 같음을 검증하면 됩니다.

매번 Exception을 생성해주지 않고, 존재하는 Exception을 재사용한다는 측면도 있어서, 메모리 상의 이득도 볼수 있을 거라 생각합니다.

> 현재는 Lab, Member 이 두가지 경우에 대해서만 진행했는데, 다른 분들의 의견을 들어보고 추가작업 진행할 생각입니다.


Close #116 #12 