### PR TITLE
Revert "chore: checkstyle 수정"

### DIFF
--- a/back-end/config/gpu-im-checkstyle.xml
+++ b/back-end/config/gpu-im-checkstyle.xml
@@ -30,9 +30,15 @@
 
   <property name="severity" value="warning"/>
 
+  <!-- [newline-lf] -->
+  <module name="RegexpMultiline">
+    <property name="format" value="\r\n"/>
+    <property name="message" value="[newline-lf] Line must end with LF, not CRLF"/>
+  </module>
+
   <!-- [newline-eof] -->
   <module name="NewlineAtEndOfFile">
-    <property name="lineSeparator" value="lf_cr_crlf"/>
+    <property name="lineSeparator" value="lf"/>
   </module>
 
   <property name="fileExtensions" value="java, properties, xml"/>


### PR DESCRIPTION
Reverts woowacourse-teams/2021-gpu-is-mine#210

https://github.com/woowacourse-teams/2021-gpu-is-mine/issues/211#issuecomment-889962220 에 따라 LF로 개행문자를 통일시키기로 했으니, 

LF인지 아닌지 확인하는 코드는 살려두기 위해 #210 을  revert 해도 될까요?  