### PR TITLE
chore: dev, prod 설정파일에 mariadb 연결 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,4 +10,3 @@ logs
 
 # Local Netlify folder
 .netlify
-/back-end/src/main/resources/application-db.properties

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ logs
 
 # Local Netlify folder
 .netlify
+/back-end/src/main/resources/application-db.properties

--- a/back-end/.gitignore
+++ b/back-end/.gitignore
@@ -39,3 +39,5 @@ logs
 ### Private ###
 /src/main/resources/application-mail.properties
 /src/main/resources/application-encryption.properties
+/src/main/resources/application-db.properties
+/docker/docker-compose.yml

--- a/back-end/build.gradle
+++ b/back-end/build.gradle
@@ -34,15 +34,25 @@ dependencies {
     compile 'io.springfox:springfox-swagger2:2.9.2'
     compile 'io.springfox:springfox-swagger-ui:2.9.2'
 
+    testRuntimeOnly 'com.h2database:h2'
     runtimeOnly 'com.h2database:h2'
+    runtimeOnly 'org.mariadb.jdbc:mariadb-java-client'
 }
 
 processResources.dependsOn('copyPrivate')
 
 task copyPrivate(type: Copy) {
-    from '../private-configuration'
-    include "**/*.properties"
-    into 'src/main/resources'
+    copy{
+        from '../private-configuration'
+        include "*.properties"
+        into 'src/main/resources'
+    }
+
+    copy{
+        from '../private-configuration'
+        include "docker-compose.yml"
+        into './docker'
+    }
 }
 
 test {

--- a/back-end/src/main/resources/application-dev.properties
+++ b/back-end/src/main/resources/application-dev.properties
@@ -1,8 +1,4 @@
-spring.datasource.url=jdbc:h2:mem:testdb
-spring.datasource.driverClassName=org.h2.Driver
-spring.datasource.username=sa
-spring.datasource.password=
-spring.h2.console.enabled=true
-spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
+spring.config.import=./application-db.properties
+spring.jpa.database-platform=org.hibernate.dialect.MariaDBDialect
 spring.jpa.hibernate.ddl-auto=create
 request.origins=*

--- a/back-end/src/main/resources/application-prod.properties
+++ b/back-end/src/main/resources/application-prod.properties
@@ -1,10 +1,6 @@
-# db 설정 필요
-#spring.datasource.url=jdbc:h2:mem:testdb
-#spring.datasource.driverClassName=org.h2.Driver
-#spring.datasource.username=sa
-#spring.datasource.password=
-#spring.h2.console.enabled=true
-#spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
+spring.config.import=./application-db.properties
+spring.jpa.database-platform=org.hibernate.dialect.MariaDBDialect
+spring.jpa.hibernate.ddl-auto=create
 
 request.origins=\
   https://gpu-is-mine.netlify.app,\


### PR DESCRIPTION


# 사용설명서

1. submodule 파일을 최신 커밋으로 업데이트! 
- submodule 파일에 `docker-compose.yml`, `application-db.properties` 가 추가되었습니다.
- submodule 파일을 새로운 커밋으로 업데이트 해준 뒤(이미 서브모듈을 가져온적 있다면 `git submodule update`) build.gradle에서 copyPrivate 을 돌리면 새롭게 추가된 서브모듈 파일 2개가 추가될 거에요.

2. 로컬에서 돌려보고 싶다면?!
- back-end/docker/docker-compose 파일에서 volume 내용을 주석처리 (로컬 컴퓨터에 마운팅은 보통 막아놔서 주석처리하고 돌려야 해요. 실제로 우리 로컬 컴퓨터에는 DB 내용이 필요 없으니까요)
- `docker-compose up -d` 로 도커 컨테이너 띄우기 (터미널에서 docker-compose 파일이 있는 곳에서 띄워야 하는거 아시죠?!ㅎㅎㅎ `back-end/docker/docker-compose.yml` 에 생성되게 만들어 놨어요~)
- `-Dspring.profiles.active=dev` 옵선으로 실행
- 잘 되는지 확인 👍 

# 참고
- 비밀번호는 임의로 지정하였습니다. 수정하고 싶다면 알려주세요 :D
- 현재는 dev, prod 모두 `spring.jpa.hibernate.ddl-auto=create` 로 설정되어 있어요. 현재 시스템에서는 이렇게 진행하고 추후 수정이 DDL이 결정나면 변경하여 진행해야 할 듯 합니다. 이 부분에 대해서도 의견 주세요 :D