### PR TITLE
fix: 인터셉터에서 options인 경우 true로 수정

### DIFF
--- a/back-end/src/main/java/mine/is/gpu/auth/ui/LoginInterceptor.java
+++ b/back-end/src/main/java/mine/is/gpu/auth/ui/LoginInterceptor.java
@@ -8,6 +8,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import org.springframework.http.HttpMethod;
 import org.springframework.stereotype.Component;
 import org.springframework.web.servlet.HandlerInterceptor;
 
@@ -23,6 +24,10 @@ public class LoginInterceptor implements HandlerInterceptor {
 
     @Override
     public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) {
+        if (HttpMethod.OPTIONS.matches(request.getMethod())) {
+            return true;
+        }
+
         String credentials = AuthorizationExtractor.extract(request);
         if (credentials == null) {
             throw AuthorizationException.UNAUTHORIZED_USER.getException();


### PR DESCRIPTION
확인 결과 인터셉터에 preflight 요청이 왔을 떄, interceptor로직이 실행되고 이 과정에서 에러가 터지는 것을 발견해서 수정했습니다.

```
###### HTTP Request ######
OPTIONS /api/labs/1/jobs HTTP/1.0
host: app
connection: close
accept: */*
access-control-request-method: GET
access-control-request-headers: authorization
origin: https://duupyu9at80bw.cloudfront.net
user-agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/92.0.4515.107 Safari/537.36
sec-fetch-mode: cors
sec-fetch-site: cross-site
sec-fetch-dest: empty
referer: https://duupyu9at80bw.cloudfront.net/
accept-encoding: gzip, deflate, br
accept-language: ko-KR,ko;q=0.9,en-US;q=0.8,en;q=0.7

###### HTTP Response ######
HTTP/1.1 500 Internal Server Error
Access-Control-Expose-Headers: Location, Authorization
Access-Control-Allow-Origin: https://duupyu9at80bw.cloudfront.net
Access-Control-Allow-Methods: GET
Access-Control-Allow-Credentials: true
Connection: close
Vary: Origin
Access-Control-Max-Age: 1800
Content-Length: 0
Access-Control-Allow-Headers: authorization
Date: Tue, 03 Aug 2021 07:30:12 GMT
Allow: GET, HEAD, POST, PUT, DELETE, TRACE, OPTIONS, PATCH

ERROR 21-08-03 07:30:14 [[dispatcherServlet]:175] - Servlet.service() for servlet [dispatcherServlet] in context with path [] threw exception [Request processing failed; nested exception is mine.is.gpu.exception.http.UnauthorizedException: 접근 권한이 없는 사용자 입니다.] with root cause
mine.is.gpu.exception.http.UnauthorizedException: 접근 권한이 없는 사용자 입니다.
        at mine.is.gpu.auth.exception.AuthorizationException.<clinit>(AuthorizationException.java:10)
        at mine.is.gpu.auth.ui.LoginInterceptor.preHandle(LoginInterceptor.java:28)
        at org.springframework.web.servlet.HandlerExecutionChain.applyPreHandle(HandlerExecutionChain.java:148)
        at org.springframework.web.servlet.DispatcherServlet.doDispatch(DispatcherServlet.java:1055)
        at org.springframework.web.servlet.DispatcherServlet.doService(DispatcherServlet.java:962)
        at org.springframework.web.servlet.FrameworkServlet.processRequest(FrameworkServlet.java:1006)
        at org.springframework.web.servlet.FrameworkServlet.doOptions(FrameworkServlet.java:945)
        at javax.servlet.http.HttpServlet.service(HttpServlet.java:661)
        at org.springframework.web.servlet.FrameworkServlet.service(FrameworkServlet.java:883)
        at javax.servlet.http.HttpServlet.service(HttpServlet.java:733)
        at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:227)
        at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:162)
        at org.apache.tomcat.websocket.server.WsFilter.doFilter(WsFilter.java:53)
        at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:189)
        at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:162)
        at ch.qos.logback.access.servlet.TeeFilter.doFilter(TeeFilter.java:53)
        at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:189)
        at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:162)
        at org.springframework.web.filter.RequestContextFilter.doFilterInternal(RequestContextFilter.java:100)
        at org.springframework.web.filter.OncePerRequestFilter.doFilter(OncePerRequestFilter.java:119)
        at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:189)
        at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:162)
        at org.springframework.web.filter.FormContentFilter.doFilterInternal(FormContentFilter.java:93)
```