### PR TITLE
chore : jacoco 설정

### DIFF
--- a/back-end/build.gradle
+++ b/back-end/build.gradle
@@ -3,6 +3,7 @@ plugins {
     id 'io.spring.dependency-management' version '1.0.11.RELEASE'
     id 'java'
     id 'checkstyle'
+    id 'jacoco'
 }
 
 group = 'com.example'
@@ -51,10 +52,42 @@ task copyPrivate(type: Copy) {
 
 test {
     useJUnitPlatform()
+    finalizedBy 'jacocoTestReport'
+    jacoco {
+        enabled = true
+    }
 }
 
 checkstyle {
     maxWarnings = 0
     configFile = file("${rootDir}/config/gpu-im-checkstyle.xml")
     toolVersion = "8.39"
+}
+
+jacoco {
+    toolVersion = '0.8.5'
+}
+
+jacocoTestReport {
+    reports {
+        html.enabled true
+        xml.enabled false
+        csv.enabled false
+    }
+    finalizedBy 'jacocoTestCoverageVerification'
+}
+
+jacocoTestCoverageVerification {
+    violationRules {
+        rule {
+            enabled = false
+            element = 'CLASS'
+
+            limit {
+                counter = 'LINE'
+                value = 'TOTALCOUNT'
+                maximum = 200
+            }
+        }
+    }
 }


### PR DESCRIPTION
jacoco로 코드 커버리지를 확인 할 수 있는 설정을 추가했습니다.
./gradlew test 후 build/reports/jacoco/test/html/index.html을 확인하면 전체 커버리지를 확인할 수 있습니다.

이 커버리지 결과로 빌드시 verification을 줄 수도 있으나 현재 코드는 커버리지를 생각하지 않고 짠 코드가 대다수라 
우선 이 검증은 하지 않도록 했습니다.

추가로 매번 html로 확인하는게 불편하실테니, 이후에는 sonarqube를 도입하여 더 편하게 확인할 수 있도록 할 생각입니다.