### PR TITLE
chore: cross-env를 사용해서 script 환경변수 설정

### DIFF
--- a/front-end/package.json
+++ b/front-end/package.json
@@ -35,6 +35,7 @@
     "@types/styled-components": "^5.1.11",
     "@typescript-eslint/eslint-plugin": "^4.28.1",
     "@typescript-eslint/parser": "^4.28.1",
+    "cross-env": "^7.0.3",
     "eslint": "^7.30.0",
     "eslint-config-airbnb": "^18.2.1",
     "eslint-config-airbnb-typescript": "^12.3.1",
@@ -69,9 +70,9 @@
     "styled-components": "^5.3.0"
   },
   "scripts": {
-    "start": "NODE_ENV=production webpack serve ",
-    "dev": "NODE_ENV=development webpack serve",
-    "build": "NODE_ENV=production webpack",
+    "start": "cross-env NODE_ENV=production webpack serve ",
+    "dev": "cross-env NODE_ENV=development webpack serve",
+    "build": "cross-env NODE_ENV=production webpack",
     "storybook": "start-storybook -p 6006",
     "build-storybook": "build-storybook",
     "lint": "eslint --cache --fix .",

--- a/front-end/yarn.lock
+++ b/front-end/yarn.lock
@@ -5211,7 +5211,14 @@ create-react-context@0.3.0:
     gud "^1.0.0"
     warning "^4.0.3"
 
-cross-spawn@7.0.3, cross-spawn@^7.0.0, cross-spawn@^7.0.2, cross-spawn@^7.0.3:
+cross-env@^7.0.3:
+  version "7.0.3"
+  resolved "https://registry.yarnpkg.com/cross-env/-/cross-env-7.0.3.tgz#865264b29677dc015ba8418918965dd232fc54cf"
+  integrity sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==
+  dependencies:
+    cross-spawn "^7.0.1"
+
+cross-spawn@7.0.3, cross-spawn@^7.0.0, cross-spawn@^7.0.1, cross-spawn@^7.0.2, cross-spawn@^7.0.3:
   version "7.0.3"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.3.tgz#f73a85b9d5d41d045551c177e2882d4ac85728a6"
   integrity sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==


### PR DESCRIPTION
기존의 FE 실행 스크립트는 아래와 같습니다. 
```json
  "scripts": {
    "start": "NODE_ENV=production webpack serve ",
    "dev": "NODE_ENV=development webpack serve",
    "build": "NODE_ENV=production webpack",
```

위와 같이 환경변수를 설정하고 커맨드를 실행하는 방식이 윈도우에서는 작동하지 않습니다.

(`start`의 경우, `%NODE_ENV%=production webpack serve` 라고 해야하는 것으로 알고 있음)


따라서 OS간 차이를 조정해주는 cross-env 를 도입합니다