### PR TITLE
refactor: test profile 추가

### DIFF
--- a/back-end/src/main/java/mine/is/gpu/DataLoader.java
+++ b/back-end/src/main/java/mine/is/gpu/DataLoader.java
@@ -18,8 +18,8 @@ import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
-//@Profile("dev")
-//@Component
+@Profile("local")
+@Component
 public class DataLoader implements CommandLineRunner {
     private final LabRepository labRepository;
     private final GpuServerRepository gpuServerRepository;
@@ -30,9 +30,9 @@ public class DataLoader implements CommandLineRunner {
     private final MemberService memberService;
 
     public DataLoader(LabRepository labRepository,
-            GpuServerRepository gpuServerRepository,
-            GpuBoardRepository gpuBoardRepository, MemberRepository memberRepository,
-            JobRepository jobRepository, MemberService memberService) {
+                      GpuServerRepository gpuServerRepository,
+                      GpuBoardRepository gpuBoardRepository, MemberRepository memberRepository,
+                      JobRepository jobRepository, MemberService memberService) {
         this.labRepository = labRepository;
         this.gpuServerRepository = gpuServerRepository;
         this.gpuBoardRepository = gpuBoardRepository;

--- a/back-end/src/main/resources/application-test.properties
+++ b/back-end/src/main/resources/application-test.properties
@@ -1,0 +1,10 @@
+spring.datasource.url=jdbc:h2:mem:testdb
+spring.datasource.driverClassName=org.h2.Driver
+spring.datasource.username=sa
+spring.datasource.password=
+spring.h2.console.enabled=true
+spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
+spring.jpa.hibernate.ddl-auto=create
+spring.jpa.show-sql=false
+spring.jpa.properties.hibernate.format_sql=true
+request.origins=*

--- a/back-end/src/test/java/mine/is/gpu/AcceptanceTest.java
+++ b/back-end/src/test/java/mine/is/gpu/AcceptanceTest.java
@@ -15,7 +15,9 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.boot.web.server.LocalServerPort;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ActiveProfiles;
 
+@ActiveProfiles("test")
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
 public class AcceptanceTest {

--- a/back-end/src/test/java/mine/is/gpu/gpuserver/application/GpuServerServiceTest.java
+++ b/back-end/src/test/java/mine/is/gpu/gpuserver/application/GpuServerServiceTest.java
@@ -26,8 +26,10 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
 
+@ActiveProfiles("test")
 @SpringBootTest
 @Transactional
 public class GpuServerServiceTest {

--- a/back-end/src/test/java/mine/is/gpu/gpuserver/domain/repository/GpuServerRepositoryTest.java
+++ b/back-end/src/test/java/mine/is/gpu/gpuserver/domain/repository/GpuServerRepositoryTest.java
@@ -17,10 +17,12 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
-import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.test.context.ActiveProfiles;
 
+@ActiveProfiles("test")
 @DataJpaTest
 public class GpuServerRepositoryTest {
     @Autowired

--- a/back-end/src/test/java/mine/is/gpu/gpuserver/ui/GpuServerControllerTest.java
+++ b/back-end/src/test/java/mine/is/gpu/gpuserver/ui/GpuServerControllerTest.java
@@ -19,8 +19,10 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
 
+@ActiveProfiles("test")
 @Transactional
 @SpringBootTest
 class GpuServerControllerTest {

--- a/back-end/src/test/java/mine/is/gpu/job/application/JobServiceTest.java
+++ b/back-end/src/test/java/mine/is/gpu/job/application/JobServiceTest.java
@@ -34,8 +34,10 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
 
+@ActiveProfiles("test")
 @SpringBootTest
 @Transactional
 class JobServiceTest {

--- a/back-end/src/test/java/mine/is/gpu/job/ui/JobControllerTest.java
+++ b/back-end/src/test/java/mine/is/gpu/job/ui/JobControllerTest.java
@@ -32,8 +32,10 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
 
+@ActiveProfiles("test")
 @Transactional
 @SpringBootTest
 public class JobControllerTest {

--- a/back-end/src/test/java/mine/is/gpu/lab/application/LabServiceTest.java
+++ b/back-end/src/test/java/mine/is/gpu/lab/application/LabServiceTest.java
@@ -25,8 +25,10 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
 
+@ActiveProfiles("test")
 @SpringBootTest
 @Transactional
 class LabServiceTest {

--- a/back-end/src/test/java/mine/is/gpu/lab/domain/repository/LabRepositoryTest.java
+++ b/back-end/src/test/java/mine/is/gpu/lab/domain/repository/LabRepositoryTest.java
@@ -8,7 +8,9 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.test.context.ActiveProfiles;
 
+@ActiveProfiles("test")
 @DataJpaTest
 public class LabRepositoryTest {
     @Autowired

--- a/back-end/src/test/java/mine/is/gpu/member/application/MemberServiceTest.java
+++ b/back-end/src/test/java/mine/is/gpu/member/application/MemberServiceTest.java
@@ -30,8 +30,10 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
 
+@ActiveProfiles("test")
 @SpringBootTest
 @Transactional
 class MemberServiceTest {

--- a/back-end/src/test/java/mine/is/gpu/member/domain/repository/MemberRepositoryTest.java
+++ b/back-end/src/test/java/mine/is/gpu/member/domain/repository/MemberRepositoryTest.java
@@ -10,7 +10,9 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.test.context.ActiveProfiles;
 
+@ActiveProfiles("test")
 @DataJpaTest
 public class MemberRepositoryTest {
     @Autowired

--- a/back-end/src/test/java/mine/is/gpu/worker/JobRepositoryTest.java
+++ b/back-end/src/test/java/mine/is/gpu/worker/JobRepositoryTest.java
@@ -19,7 +19,9 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.context.ActiveProfiles;
 
+@ActiveProfiles("test")
 @DataJpaTest
 class JobRepositoryTest {
     @Autowired

--- a/back-end/src/test/java/mine/is/gpu/worker/application/WorkerServiceTest.java
+++ b/back-end/src/test/java/mine/is/gpu/worker/application/WorkerServiceTest.java
@@ -27,8 +27,10 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
 
+@ActiveProfiles("test")
 @SpringBootTest
 @Transactional
 @DisplayName("[WorkerService]")


### PR DESCRIPTION
close #218

test profile을 추가했습니다.
- application-test.properties 파일 생성
- DB를 찌르는 테스트 클래스에 `@ActiveProfiles("test")` 추가

DataLoader의 Profile을 local로 변경
- 테스트 코드와 충돌 방지

추후에 Test용 DataLoader를 따로 만들고, `@Profile("test")`를 붙여서 활용 가능