### PR TITLE
fix: style 태그를 이용하여 google webfont import

### DIFF
--- a/front-end/public/index.html
+++ b/front-end/public/index.html
@@ -5,6 +5,9 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>GPU 내껀데</title>
+    <style>
+      @import url("https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@100;300;400;500;700;900&display=swap");
+    </style>
   </head>
   <body>
     <div id="root"></div>

--- a/front-end/src/styles/GlobalStyle.tsx
+++ b/front-end/src/styles/GlobalStyle.tsx
@@ -6,7 +6,6 @@ const GlobalStyle = createGlobalStyle`
   ${reset}
   ${colors}
 
-  @import url("https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@100;300;400;500;700;900&display=swap");
 
   :root {
     font-family: "Noto Sans KR", sans-serif;


### PR DESCRIPTION
Styled Component 사용시 createGlobalStyles 에서 @import 를 쓰지 말라고 합니다. 

이로 인해 @import 이후의 스타일이 적용되지 않는 버그를 발견하여

public/index.html  내의 style 태그 에서 @import 하는 것으로 수정합니다