### PR TITLE
feat: 토큰 만료 시간 추가

### DIFF
--- a/back-end/src/main/java/mine/is/gpu/auth/application/AuthService.java
+++ b/back-end/src/main/java/mine/is/gpu/auth/application/AuthService.java
@@ -40,7 +40,8 @@ public class AuthService {
         }
 
         String token = jwtTokenProvider.createToken(request.getEmail());
-        return new LoginResponse(token);
+        Long validityInMilliseconds = jwtTokenProvider.getValidityInMilliseconds();
+        return new LoginResponse(token, validityInMilliseconds);
     }
 
     private Account findUser(LoginRequest request) {

--- a/back-end/src/main/java/mine/is/gpu/auth/dto/LoginResponse.java
+++ b/back-end/src/main/java/mine/is/gpu/auth/dto/LoginResponse.java
@@ -3,15 +3,21 @@ package mine.is.gpu.auth.dto;
 public class LoginResponse {
 
     private String accessToken;
+    private Long expires;
 
     public LoginResponse() {
     }
 
-    public LoginResponse(String accessToken) {
+    public LoginResponse(String accessToken, Long expires) {
         this.accessToken = accessToken;
+        this.expires = expires;
     }
 
     public String getAccessToken() {
         return accessToken;
+    }
+
+    public Long getExpires() {
+        return expires;
     }
 }

--- a/back-end/src/main/java/mine/is/gpu/auth/infrastructure/JwtTokenProvider.java
+++ b/back-end/src/main/java/mine/is/gpu/auth/infrastructure/JwtTokenProvider.java
@@ -46,5 +46,8 @@ public class JwtTokenProvider {
             return false;
         }
     }
-}
 
+    public Long getValidityInMilliseconds() {
+        return validityInMilliseconds;
+    }
+}

--- a/back-end/src/test/java/mine/is/gpu/auth/AuthAcceptanceTest.java
+++ b/back-end/src/test/java/mine/is/gpu/auth/AuthAcceptanceTest.java
@@ -12,6 +12,7 @@ import mine.is.gpu.lab.dto.LabRequest;
 import mine.is.gpu.member.dto.request.MemberRequest;
 import mine.is.gpu.member.ui.MemberAcceptanceTest;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
@@ -140,7 +141,7 @@ public class AuthAcceptanceTest extends AcceptanceTest {
     @Test
     @DisplayName("Bearer Auth 유효하지 않은 토큰")
     void myInfoWithWrongBearerAuth() {
-        LoginResponse loginResponse = new LoginResponse("invalid_token");
+        LoginResponse loginResponse = new LoginResponse("invalid_token", 3600000L);
 
         RestAssured
                 .given()
@@ -183,6 +184,25 @@ public class AuthAcceptanceTest extends AcceptanceTest {
                 .accept(MediaType.APPLICATION_JSON_VALUE)
                 .when()
                 .get("/api/labs/" + Long.MAX_VALUE)
+                .then()
+                .statusCode(HttpStatus.UNAUTHORIZED.value());
+    }
+
+    @Disabled
+    @DisplayName("권한이 있는 사용자가 만료된 토큰으로 접근한다.")
+    @Test
+    void expiredToken() throws InterruptedException {
+        회원_등록되어_있음(memberRequest);
+        LoginResponse loginResponse = 로그인되어_있음(EMAIL, PASSWORD);
+        Thread.sleep(3600000);
+
+        RestAssured
+                .given()
+                .auth()
+                .oauth2(loginResponse.getAccessToken())
+                .accept(MediaType.APPLICATION_JSON_VALUE)
+                .when()
+                .get("/api/labs/" + memberRequest.getLabId())
                 .then()
                 .statusCode(HttpStatus.UNAUTHORIZED.value());
     }


### PR DESCRIPTION
close #345

json 변환 라이브러리는 getter가 있어야 온전히 json으로 변환을 해주네요.
expires 필드를 추가했는데 getter를 설정 안 했더니 json에 accessToken 값만 보내지더라구요.

토큰 만료 시간 테스트를 추가했습니다.
만료 시간을 짧게 주고 확인 해봤습니다.
실제 만료 시간은 너무 길어서 테스트에 Disabled 걸어놨습니다.