### PR TITLE
fix: 모바일 뷰에서 sub header 메뉴 열기

### DIFF
--- a/front-end/src/domains/SubHeader/SubHeader.styled.ts
+++ b/front-end/src/domains/SubHeader/SubHeader.styled.ts
@@ -28,12 +28,4 @@ export const StyledSubHeader = styled.header`
   .title__name:hover {
     color: var(--secondary-600);
   }
-
-  .lab-name {
-    display: none;
-
-    ${up("tablet")} {
-      display: inherit;
-    }
-  }
 `;

--- a/front-end/src/domains/SubHeader/SubHeader.tsx
+++ b/front-end/src/domains/SubHeader/SubHeader.tsx
@@ -82,11 +82,13 @@ const SubHeader = ({ children, ...rest }: SubHeaderProps) => {
           ))}
         </div>
 
-        <Text className="lab-name" size="md" weight="medium">
-          {labName}
-        </Text>
+        {!isMobile && (
+          <Text size="md" weight="medium">
+            {labName}
+          </Text>
+        )}
         {isMobile && (
-          <button type="button" className="down-arrow" onClick={() => toggleIsNavVisible()}>
+          <button type="button" onClick={() => toggleIsNavVisible()}>
             {isNavVisible ? "▲" : "▼"}
           </button>
         )}


### PR DESCRIPTION
close #394 

원인
+ 서브 헤더 메뉴가 열린 상태에서 창을 키우면 확장된 영역만큼 전부 차지함

해결
+ 정확한 이유는 모르겠으나 css로 처리하는 로직 제거 및 컴포넌트 단에서 uesBreakpoints를 활용하여 모바일의 경우 숨기도록 대응