### PR TITLE
hotfix: 이메일 네이버에서 버튼 왼쪽정렬 템플릿 대응

### DIFF
--- a/back-end/src/main/resources/templates/basic-template.html
+++ b/back-end/src/main/resources/templates/basic-template.html
@@ -95,7 +95,10 @@
                         text-align: center;
                       "
                 >
-                  <table align="center">
+                  <table
+                      align="center"
+                      style="margin-left: auto; margin-right: auto"
+                  >
                     <tr>
                       <td>
                         <a
@@ -104,6 +107,7 @@
                             target="_blank"
                             style="
                                 background-color: #222E3D;
+                                padding: 10px;
                                 color: #F5B85E;
                                 display: block;
                                 width: 243px;


### PR DESCRIPTION
# gmail
![image](https://user-images.githubusercontent.com/66905013/139223844-64236325-2ad5-45d6-a0ab-3b1a2bef3efb.png)

# naver
![image](https://user-images.githubusercontent.com/66905013/139223934-41dd5680-631a-4d7e-8f42-1a0055247583.png)

급한대로 보기에 밉지만 않게 수정했어요.